### PR TITLE
Bug fix: Masked hex grid

### DIFF
--- a/floater/generators.py
+++ b/floater/generators.py
@@ -133,7 +133,7 @@ class FloatSet(object):
             1D array of float z coordinates
         """
         if self.dims==3:
-            xx, yy, zz = self.get_rectmesh()
+            xx, yy, zz = np.meshgrid(self.x, self.y,self.zvect)
             # modify to be even-R horizontal offset
             xx[::2] += self.dx/4
             xx[1::2] -= self.dx/4
@@ -141,7 +141,7 @@ class FloatSet(object):
                 xx, yy, zz = self.subset_floats_from_mask(xx, yy, zz)
             return xx,yy,zz
         else:
-            xx, yy = self.get_rectmesh()
+            xx, yy = np.meshgrid(self.x, self.y)
             # modify to be even-R horizontal offset 
             xx[::2] += self.dx/4
             xx[1::2] -= self.dx/4

--- a/floater/test/test_hex.py
+++ b/floater/test/test_hex.py
@@ -1,0 +1,53 @@
+from __future__ import print_function
+
+from floater import generators as gen
+import numpy as np
+import os
+import pytest
+import xarray as xr
+
+domain_geometries = [
+    # xlim, ylim, dx, dy, model_grid
+    ((-50,50), (-50,50), 10,10, None)
+    ]
+
+grid_dict=dict(
+    lon=np.arange(-30,30,1),
+    lat=np.arange(-30,30,1),
+    land_mask=np.ones((60,60))
+    ) 
+
+
+@pytest.fixture(params=domain_geometries)
+def hex_masked_grid(request):
+    xlim, ylim, dx, dy, _ = request.param
+    test = gen.FloatSet(xlim, ylim, dx, dy,model_grid=grid_dict) 
+    rec_g = np.asarray(test.get_rectmesh())
+    hex_g = np.asarray(test.get_hexmesh())
+    grids_parm=dict(hex=hex_g,dx=dx,dy=dy)
+    return grids_parm
+
+def test_hex_grid(hex_masked_grid):
+    """Make sure we can create masked hexagonal grids correctly."""
+    grids_parm=hex_masked_grid
+    # Make sure the separation between grid points is constant
+    # (i.e identical to dx)
+    grid_diff=np.diff(grids_parm['hex'][0,:].reshape(grids_parm['dx'],grids_parm['dy']))
+    assert np.all(grid_diff==grids_parm['dx'])
+
+if __name__ == "__main__":
+    import pylab as plt 
+    xlim, ylim, dx, dy, _ = domain_geometries[0]
+
+    test = gen.FloatSet(xlim, ylim, dx, dy,model_grid=grid_dict) 
+    rec_g = np.asarray(test.get_rectmesh())
+    hex_g = np.asarray(test.get_hexmesh())
+    grids_parm=dict(rec=rec_g,hex=hex_g,dx=dx)
+
+    dhex=grids_parm['hex']
+    drec=grids_parm['rec']
+
+    plt.plot(dhex[0,:],dhex[1,:],'x',label='Hexagonal Grid')
+    plt.plot(drec[0,:],drec[1,:],'or',label='Rectangular Grid')
+    plt.legend()
+    plt.show()


### PR DESCRIPTION
While implementing floaters and MITgcm to advect particles, I've noticed that the masked hexagonal grid has a bug. In which every 2 grid points in x are shifted by [dx/4](https://github.com/rabernat/floater/blob/004fe5afe78f55444d4e5a4f09cdf89d20532aa7/floater/generators.py#L146), instead of each row of the grid:

![bug_grid_shifted](https://user-images.githubusercontent.com/9144063/73908223-171e2a00-48fd-11ea-8c78-e1febff9278a.png)

This bug is a consequence of the function get_rectmesh returning an array (length = number of particles) instead of a grid (shape = nx * ny grid points) when the routine `subset_floats_from_mask(xx, yy, zz)` is executed. The solution to this problem is to reconstruct the regular grid and then execute `subset_floats_from_mask(xx, yy, zz)`.

![expected_hex_grid](https://user-images.githubusercontent.com/9144063/73908347-79772a80-48fd-11ea-8295-42874505d4be.png)
